### PR TITLE
Added support for empty response bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Each one of these methods returns a Promise with the response as the parameter.
 ## Limitations
 
 * This library only supports JSON request and response bodies. If the response is not
-a JSON object, it will throw a JSON parse error.
+a JSON object, it will throw a JSON parse error. If the response is empty, it will return undefined.
 * It is labeled as _React Native_, even when it has no RN dependencies and could (in theory)
 be used in any JavaScript project. The reason behind this is that the stack used (ES6 and
 `fetch`) comes out of the box with React Native, and

--- a/index.js
+++ b/index.js
@@ -40,14 +40,17 @@ export default class RestClient {
       Object.assign(opts, { body: JSON.stringify(body) });
     }
     const fetchPromise = () => fetch(fullRoute, opts);
+    const extractResponse = response =>
+      response.text().then(text => text? JSON.parse(text) : undefined);
+
     if (this.devMode && this.simulatedDelay > 0) {
       // Simulate an n-second delay in every request
       return this._simulateDelay()
         .then(() => fetchPromise())
-        .then(response => response.json());
+        .then(extractResponse);
     } else {
       return fetchPromise()
-        .then(response => response.json());
+        .then(extractResponse);
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/javorosas/react-native-rest-client/issues/3

Useful for HTTP responses which typically contain no data, for instance:

* HTTP 201 Created
* HTTP 202 Accepted
* HTTP 204 No Content

and so on.

I bumped the version because I changed the signature of _fetch