### PR TITLE
Added: Typescript definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for react-native-rest-client v0.1.1
+// Project: https://github.com/javorosas/react-native-rest-client
+// Definitions by: Nick Hope <https://github.com/nicktoony/>
+
+declare module "react-native-rest-client" {
+    class RestClient {
+        constructor(baseUrl?: string, options?: 
+            { headers?: object, devMode?: boolean, simulatedDelay?: number });
+
+        GET<T>(route: string, query?: object, body?: object): Promise<T>;
+        POST<T>(route: string, query?: object, body?: object): Promise<T>;
+        PUT<T>(route: string, query?: object, body?: object): Promise<T>;
+        DELETE<T>(route: string, query?: object, body?: object): Promise<T>;
+    }
+
+    export = RestClient;
+}

--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
   "homepage": "https://github.com/javorosas/react-native-rest-client#readme",
   "dependencies": {
     "qs": "^6.3.0"
-  }
+  },
+  "types": "./index.d.ts"
 }


### PR DESCRIPTION
I have added a Typescript definition file to allow Typescript users to make good use of this library. Typescript users can use the RestClient as follows:

```
import RestClient from 'react-native-rest-client';

export class MyAPI extends RestClient {
   constructor () {
      super('https://yourapi');
    }

    getPost() {
        return this.GET<Post>('/post')
            .then(response => {
                
            });
    }
};
```

Works for my use case - let me know if you'd like any changes.